### PR TITLE
fix: add english translation for Abb.

### DIFF
--- a/ads/header.tex
+++ b/ads/header.tex
@@ -349,9 +349,16 @@
 % Schriftart in Captions etwas kleiner
 \addtokomafont{caption}{\small}
 % Caption nur als "Abb.", nicht als "Abbildung"
-\usepackage[
-    figurename=Abb.
-]{caption}
+\iflang{de}{
+    \usepackage[
+        figurename=Abb.
+    ]{caption}
+}
+\iflang{en}{
+    \usepackage[
+        figurename=Fig.
+    ]{caption}
+}
 
 \usepackage{subfig}
 


### PR DESCRIPTION
if language is set to english a figure is still displayed as Abb. and not as Fig.