### PR TITLE
Addchap does not work

### DIFF
--- a/ads/appendix.tex
+++ b/ads/appendix.tex
@@ -15,4 +15,4 @@
     \printbibliography
 \fi
 
-\addchap{\langanhang}
+\chapter{\langanhang}


### PR DESCRIPTION
If section are added in the appendix they are attributed to the last chapter in content